### PR TITLE
LodelParser: définir les variables optionnelles non définie dans l'appel...

### DIFF
--- a/lodel/scripts/parser.php
+++ b/lodel/scripts/parser.php
@@ -1401,6 +1401,14 @@ PHP;
 					}
 				}
 			}
+			// define undefined optional parameter, so the ones in the context do not overwrite them
+			if (!empty($defattr['OPTIONAL'])) {
+				$optional = explode(',', strtoupper($defattr['OPTIONAL']));
+				foreach ($optional as $arg) {
+					if (!isset ($attrs[$arg]))
+						$attrs[$arg] = '';
+				}
+			}
 
 			// build the call
 			unset ($attrs['NAME']);


### PR DESCRIPTION
... de <FUNC

En effet si les variables sont déjà défini dans le contexte elles le seront dans la <FUNC> ce qui n'est pas ce qui est attendu
