### PR TITLE
Cache spécifique pour le chargement de fichier

### DIFF
--- a/lodel/src/lodel/edition/oochargement.php
+++ b/lodel/src/lodel/edition/oochargement.php
@@ -110,6 +110,7 @@ try
 	$isFrame = ! (C::get('sortietei') || C::get('sortie')) && C::get('adminlodel', 'lodeluser');
 
 	$cache = getCacheObject();
+    $file_cache_lifetime = C::get('timeout', 'cfg') ? C::get('timeout', 'cfg') : 3600;
 
 	if($fileorigin == 'upload' && !empty($_FILES['file1'])) {
 		$file = $_FILES['file1'];
@@ -213,10 +214,10 @@ try
                     }
 
                     $fileconverted = $source. '.converted';
-                    $cache->set($fileconverted, base64_encode(serialize($contents)));
+                    $cache->set($fileconverted, base64_encode(serialize($contents)), $file_cache_lifetime);
 
-                    $cache->set($source, base64_encode(file_get_contents($source)));
-                    $cache->set($tei, base64_encode(file_get_contents($tei)));
+                    $cache->set($source, base64_encode(file_get_contents($source)), $file_cache_lifetime);
+                    $cache->set($tei, base64_encode(file_get_contents($tei)), $file_cache_lifetime);
 
                     unset($contents);
                     $row = array();
@@ -346,10 +347,10 @@ try
 		}
 
 		$fileconverted = $source. '.converted';
-		$cache->set($fileconverted, base64_encode(serialize($contents)));
+		$cache->set($fileconverted, base64_encode(serialize($contents)), $file_cache_lifetime);
 
-        $cache->set($source, base64_encode(file_get_contents($source)));
-        $cache->set($tei, base64_encode(file_get_contents($tei)));
+        $cache->set($source, base64_encode(file_get_contents($source)), $file_cache_lifetime);
+        $cache->set($tei, base64_encode(file_get_contents($tei)), $file_cache_lifetime);
 
 		unset($contents);
 		$row = array();
@@ -508,11 +509,11 @@ RDF;
 			}
 
 			$fileconverted = $source. '.converted';
-			$cache->set($fileconverted, base64_encode(serialize($contents)));
+			$cache->set($fileconverted, base64_encode(serialize($contents)), $file_cache_lifetime);
 
-            $cache->set($source, base64_encode(file_get_contents($source)));
-            $cache->set($odtconverted, base64_encode(file_get_contents($odtconverted)));
-            $cache->set($tei, base64_encode(file_get_contents($tei)));
+            $cache->set($source, base64_encode(file_get_contents($source)), $file_cache_lifetime);
+            $cache->set($odtconverted, base64_encode(file_get_contents($odtconverted)), $file_cache_lifetime);
+            $cache->set($tei, base64_encode(file_get_contents($tei)), $file_cache_lifetime);
 
 			unset($contents);
 			$row = array();


### PR DESCRIPTION
 Lorsqu'un fichier est chargé par OTX, celui-ci est mis en cache, et
ce cache a une expiration qui peut être plus ou moins longue. Lorsque
le cache expire rapidement, l'utilisateur ne peut pas valider le
document car le fichier a expiré, et alors une erreur est levée.
Ce patch défini un cache spécifique basé sur le timeout de la
configuration, par défaut 1h.
