### PR TITLE
Réécriture de la détection de langue automatique

### DIFF
--- a/lodel/install/plateform/lodelconfig-default.php
+++ b/lodel/install/plateform/lodelconfig-default.php
@@ -117,6 +117,11 @@ $cfg['singledatabase']="on";
 # Nom de la session (cookie)
 $cfg['sessionname']="session{$cfg['database']}";
 
+# Détection automatique de la langue de navigation
+$cfg['detectlanguage'] = true;
+# Choix par défaut de la langue de navigation
+// $cfg['mainlanguageoption'] = 'options.metadonneessite.langueprincipale';
+
 
 # type d'URL
 $cfg['extensionscripts']="";      # extension .php ou .html pour les scripts accessibles par les internautes

--- a/lodel/src/lodel/admin/tpl/translations.html
+++ b/lodel/src/lodel/admin/tpl/translations.html
@@ -90,6 +90,11 @@
 		</tr>
 		</DO>
 	</LOOP>
+    <tfoot>
+        <tr>
+            <td colspan="4" class="texte_info">[@ADMIN.FIRST_CHOICE_IS_DEFAULT_LANG]</td>
+        </tr>
+    </tfoot>
 </table>
 
 <LET ARRAY="statuses[]">-1</LET>


### PR DESCRIPTION
La façon dont la langue était détectait n'était pas consistante et
obligeait d'avoir un cookie.
Cette réécriture permet de n'utiliser un cookie que lorsque l'utilisateur
a explicitement fait un choix de langue (via l'url ?lang=…).

La détection se fait dans l'ordre :
- choix explicite
- cookie présent
- détection automatique basé sur le HTTP_ACCEPT_LANGUAGE, si l'option
  "detectlanguage" est à true.
- option de préférence de langue du site définit dans lodelconfig.php
  ou siteconfig.php, si l'option "mainlanguageoption" est définie et
  l'option associée aussi
- sinon, on prend la langue de rank 1 dans les traductions disponibles
