### PR TITLE
Traduction des titres de groupes de champs

### DIFF
--- a/share/macros/macros_interface.html
+++ b/share/macros/macros_interface.html
@@ -134,7 +134,10 @@
                 <fieldset>
                         <legend>
                         <LOOP NAME="getGroupInfo" TABLE="tablefieldgroups" WHERE="id = [#IDGROUP]">
-                        <MACRO NAME="INTERTITLE" />
+                            <IF COND="[#ALTERTITLE]">
+                                <LET VAR="INTERTITLE">[#ALTERTITLE|multilingue([#LODELUSER.LANG])]</LET>
+                            </IF>
+                            <MACRO NAME="INTERTITLE" />
                         </LOOP>
                         </legend>
         </LOOP>


### PR DESCRIPTION
On corriger le tpl pour afficher maintenant les titres traduits des
groupes de champ, comme on affiche les titres de champs.
