### PR TITLE
Revert "Laisser la possibilité à un lodeladmin de créer une option modif...

### DIFF
--- a/lodel/scripts/logic/class.options.php
+++ b/lodel/scripts/logic/class.options.php
@@ -134,7 +134,7 @@ class OptionsLogic extends Logic {
 		switch($var) {
 		case "userrights":
 			function_exists('makeSelectUserRights') || include("commonselect.php");
-			$lodeladmin = (((!C::get('site', 'cfg') || SINGLESITE) && defined('backoffice-lodeladmin')) || C::get('adminlodel', 'lodeluser')) ? TRUE : FALSE;
+			$lodeladmin = ((!C::get('site', 'cfg') || SINGLESITE) && defined('backoffice-lodeladmin')) ? TRUE : FALSE;
 			makeSelectUserRights(isset($context['userrights']) ? $context['userrights'] : '', $lodeladmin);
 			break;
 		case "type" :


### PR DESCRIPTION
...iable uniquement par les lodeladmin"

This reverts commit c34462d8f9ff10c2d35b5f3c10e53a0609321e57.
Cette implémentation est trop lacunaire, un admin peut modifier l'option pour se la rendre modifiable.
La fonctionnalité est très compliqué à mettre en place.
