### PR TITLE
Passer #EDITIONPARAMS explicitement

### DIFF
--- a/lodel/src/lodel/admin/tpl/edit_useroptiongroups.html
+++ b/lodel/src/lodel/admin/tpl/edit_useroptiongroups.html
@@ -66,7 +66,7 @@
 		<IF COND="[#TYPE]=='passwd'"><LET VAR="value"></LET></IF>
 		<!--[ print the group ]-->
 		<label for="[#NAME]">[#TITLE] :</label>
-		<FUNC NAME="PRINT_EDIT_FIELD" FULLVARNAME="data[[#NAME]]" VARNAME="[#NAME]" VALUE="[#VALUE|htmlspecialchars]" TYPE="[#TYPE]" />
+		<FUNC NAME="PRINT_EDIT_FIELD" FULLVARNAME="data[[#NAME]]" VARNAME="[#NAME]" VALUE="[#VALUE|htmlspecialchars]" TYPE="[#TYPE]" EDITIONPARAMS="[#EDITIONPARAMS]" />
 		<br />
 		</DO>
     <ALTERNATIVE>


### PR DESCRIPTION
Le context ne pollue plus les fonctions, il faut donc passer explicitement les paramètres optionnels qui sont utiles
