### PR TITLE
Corrige un bogue d'affichage de message d'erreur quand OTX n'est pas instancié

### DIFF
--- a/lodel/scripts/otxclient.php
+++ b/lodel/scripts/otxclient.php
@@ -163,7 +163,7 @@ class OTXClient extends SoapClient
 	{
         try {
 			if(!$this->_instanciated)
-				throw new Exception("Webotx client FaultError", 'ERROR: client has not been instanciated');
+				throw new Exception("Webotx client FaultError: client has not been instanciated");
 
 			$this->_checkRequest($request);
 			// make the request and get tei result


### PR DESCRIPTION
Bonjour.
En testant Lodel 1.0, j'ai eu un souci au moment d'importer un fichier ODT pour créer un article. La raison en est que je n'ai pas de serveur OTX installé, rien que de très normal. En revanche, l'affichage du message d'erreur bogue : la boite rouge s'affiche mais il n'y a pas de texte dedans.

Après recherche dans les logs de PHP, on trouve cette erreur.
PHP Fatal error:  Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in /monserveur/htdocs/lodel/scripts/otxclient.php on line 166

À la ligne en question, il s'avère que Exception() est utilisé avec deux chaînes de caractères en argument (une scorie de l'époque où vous utilisiez SoapFault qui, lui, le permet) et qu'il n'est pas d'accord. 
J'ai fondu les deux chaînes en une et le bogue est résolu sur ma machine : la boite d'erreur reste énorme par rapport au message mais, au moins, celui-ci apparaît.
