### PR TITLE
Paramètre lang_trad pour l'export des traductions.

### DIFF
--- a/lodel/scripts/logic/class.translations.php
+++ b/lodel/scripts/logic/class.translations.php
@@ -252,7 +252,7 @@ class TranslationsLogic extends Logic {
 	{
 		function_exists('validfield') || include "validfunc.php";
 
-		$lang = isset($context['lang']) ? $context['lang'] : 'all';
+		$lang = isset($context['lang_trad']) ? $context['lang_trad'] : 'all';
 		
 		if ($lang != "all" && !validfield($lang, "lang"))
 			trigger_error("ERROR: invalid lang", E_USER_ERROR);

--- a/share/macros/macros_admin.html
+++ b/share/macros/macros_admin.html
@@ -657,8 +657,8 @@ cp_[#NAME].writeDiv();
 <DEFMACRO NAME="EXPORTER_IMPORTER_TRANSLATION">
   &nbsp;|&nbsp;
   <IF COND="[#LODELUSER.EDITOR] and (([#STATUS] lt 32) or [#LODELUSER.ADMINLODEL])">
-    <a href="index.php?do=export&lo=translations&lang=[#LANG]">[@ADMIN.EXPORT]</a>&nbsp;
-    |&nbsp;<a href="index.php?do=import&lo=translations&lang=[#LANG]">[@ADMIN.IMPORT]</a>&nbsp;|&nbsp;
+    <a href="index.php?do=export&lo=translations&lang_trad=[#LANG]">[@ADMIN.EXPORT]</a>&nbsp;
+    |&nbsp;<a href="index.php?do=import&lo=translations&lang_trad=[#LANG]">[@ADMIN.IMPORT]</a>&nbsp;|&nbsp;
   <ELSE/>
   <span class="inactif">[@ADMIN.EXPORT]</span>&nbsp;
   |&nbsp;<span class="inactif">[@ADMIN.IMPORT]</span>&nbsp;|&nbsp;


### PR DESCRIPTION
Se débarraser des paramètres lang pour autre chose que le changement de langue de l'interface.
