### PR TITLE
À l'import, vérifier que l'on ne supprime que le dossier temporaire.

### DIFF
--- a/lodel/scripts/func.php
+++ b/lodel/scripts/func.php
@@ -1438,18 +1438,17 @@ function rmtree($rep)
             $is_removable = true;
     if (!$is_removable)
             trigger_error("Interdiction d'effacer le répertoire $rep", E_USER_ERROR);
-    $fd = @opendir($rep) or trigger_error("Impossible d'ouvrir $rep", E_USER_ERROR);
+    $fd = opendir($rep) or trigger_error("Impossible d'ouvrir $rep", E_USER_ERROR);
     while (($file = readdir($fd)) !== false) {
         if('.' === $file{0}) continue;
         $file = $rep. "/". $file;
         if (is_dir($file)) { //si c'est un répertoire on execute la fonction récursivement
             rmtree($file);
-            // puis on supprime le répertoire
-            @rmdir($file);
-        } else {@unlink($file);}
+        } else {unlink($file);}
     }
     closedir($fd);
-    @rmdir($rep);
+
+    rmdir($rep);
 }
 
 define('INC_FUNC', 1);

--- a/lodel/scripts/logic/class.entities_import.php
+++ b/lodel/scripts/logic/class.entities_import.php
@@ -248,8 +248,12 @@ class Entities_ImportLogic extends Entities_EditionLogic
 				$this->_moved_images[basename($imgfile)] = $imglist[$imgfile];
 			}
 		}
-        if (isset($imgfile_path))
-            rmtree(dirname($imgfile_path));
+		// Effacer le dossier d'import — 'import_' défini dans oochargement l241 …
+		if (isset($imgfile_path)) {
+			$rep = is_dir($imgfile_path) ? $imgfile_path : dirname($imgfile_path);
+			if (!preg_match('/docannexe\/image$/',$rep) && (false !== strpos($rep, 'import_')))
+				rmtree($rep);
+		}
 	}
  
 	protected function _checkdir ($dir) 


### PR DESCRIPTION
Corrige un bug critique qui effaçait docannexe/image quand une image avait url=""
