### PR TITLE
Archive zip, meilleur feedback

### DIFF
--- a/lodel/scripts/func.php
+++ b/lodel/scripts/func.php
@@ -1410,9 +1410,17 @@ function create_zip_from_file_list($zipfile, $filelist)
 
     foreach($filelist as $path => $filename)
     {
-        $zip->addFile($path, $filename);
+        if (is_readable($path))
+            $ok = $zip->addFile($path, $filename);
+        else {
+            $zip->close();
+            return "$path is not readable";
+        }
     }
-    $zip->close();
+    $ok = $zip->close();
+    if (!$ok)
+        return $zip->getStatusString();
+    return true;
 }
 
 function glob_recursive($pattern, $flags = 0)

--- a/lodel/scripts/logic/class.data.php
+++ b/lodel/scripts/logic/class.data.php
@@ -339,11 +339,11 @@ class DataLogic
             }
 
 			/* On créé le zip dans $archivetmp */
-            create_zip_from_file_list($archivetmp, $files_and_names);
+			$ok = create_zip_from_file_list($archivetmp, $files_and_names);
 
-            @unlink($tmpdir. DIRECTORY_SEPARATOR . $outfile);
-			if (!file_exists($archivetmp)) {
-				trigger_error("ERROR: the zip command or library does not produce any output", E_USER_ERROR);
+			@unlink($tmpdir. DIRECTORY_SEPARATOR . $outfile);
+			if (!file_exists($archivetmp) || true !== $ok) {
+				trigger_error("ERROR: the zip command reported an error: «{$ok}».\nArchive: $archivetmp", E_USER_ERROR);
 			}
 
 			if($error) { // Pour avoir accès aux erreurs dans les templates


### PR DESCRIPTION
Retourner les erreurs de création du zip de backup à l'utilisateur.
Ne pas créer l'archive quand il manque des fichiers.
