### PR TITLE
Autoriser les balises <audio> et <video> dans 'xhtml:special'

### DIFF
--- a/lodel/scripts/balises.php
+++ b/lodel/scripts/balises.php
@@ -53,7 +53,7 @@ $GLOBALS['xhtmlgroups']['xhtml:fontstyle'] = array ("tt", "i", "b", "big", "smal
 
 $GLOBALS['xhtmlgroups']['xhtml:phrase'] = array ("em", "strong", "dfn", "code", "q", "samp", "kbd", "var", "cite", "abbr", "acronym", "sub", "sup", "del");
 
-$GLOBALS['xhtmlgroups']['xhtml:special'] = array ("span", "img", "object", "br", "bdo", "map", "embed", "param", "iframe");
+$GLOBALS['xhtmlgroups']['xhtml:special'] = array ("span", "img", "object", "br", "bdo", "map", "embed", "param", "iframe", "audio", "video", "source", "track");
 
 	$GLOBALS['xhtmlgroups']['xhtml:block'] = array (
 		"p", "h1", "h2", "h3", "h4", "h5", "h6", # heading


### PR DESCRIPTION
Permet de mettre des liens vers du son ou de la vidéo dans les documents externes d'un article.

Cette global est une liste blanche des balises autorisées pour certains champs d'une entité.
Typiquement cela sert dans le champ "objet" d'un document annexe.