### PR TITLE
Eviter le scroll horizontal par le bandeau backoffice

### DIFF
--- a/lodel/tpl/desk.html
+++ b/lodel/tpl/desk.html
@@ -73,6 +73,8 @@
 	img#lodelGlobalDeskDisplayer-img {
 		border:none;
 		margin:0 50%;
+		display: block;
+		padding: 5px 0;
 	}
 </IF>
 	.selectred { background-color: red; }


### PR DESCRIPTION
Quand on est connecté dans Lodel, sur les pages publiques le bandeau du backoffice "déborde" horizontalement et ajoute une marge supplémentaire à droite :

![lodel-scroll-horizontal](https://user-images.githubusercontent.com/7335302/61060554-00f9cb00-a3fb-11e9-93b0-f5ab7153a2af.png)

Ça peut sembler un détail mais en réalité dans certaines situations ça complique inutilement l'intégration des templates publics. Ce petit PR corrige ça.