### PR TITLE
Uniformisation de la récupération des URLs de site

### DIFF
--- a/lodel/scripts/class.errors.php
+++ b/lodel/scripts/class.errors.php
@@ -73,8 +73,9 @@ class LodelException extends Exception
 		{
 			$sujet = "[BUG] LODEL ".C::get('version', 'cfg')." - ".C::get('site', 'cfg');
 			$contenu = "Erreur sur la page ";
-			if (isset($_SERVER['HTTP_HOST']))
-				$contenu .= "http://".$_SERVER['HTTP_HOST'].($_SERVER['SERVER_PORT'] != 80 ? ":". $_SERVER['SERVER_PORT'] : '').$_SERVER['REQUEST_URI']." (' ".$_SERVER["REMOTE_ADDR"]." ')\n";
+			if (C::get('siteurl'))
+				$contenu .= dirname(C::get('siteurl')) . $_SERVER['REQUEST_URI'];
+
 			$contenu .= (E_USER_ERROR == $this->code || E_USER_NOTICE == $this->code || E_USER_WARNING == $this->code) ? '' : 'PHP ';
 			$contenu .= "Error ".(isset(self::$type[$this->code]) ? "(".self::$type[$this->code].")" : '')." in file '".$this->file."' on line ".$this->line." : ".$this->message;
 			@mail(C::get('contactbug', 'cfg'), $sujet, $contenu);

--- a/lodel/scripts/class.siteManage.php
+++ b/lodel/scripts/class.siteManage.php
@@ -265,11 +265,11 @@ class siteManage {
                     			C::set('path', '/'. $name);
 				}
 			}
-            
+
 			if (!C::get('url')) {
-				C::set('url', 'http://'. $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT'] && $_SERVER['SERVER_PORT'] != "80" ? ':'. $_SERVER['SERVER_PORT'] : ""). preg_replace("/\blodeladmin\/.*/", '', $_SERVER['REQUEST_URI']). substr(C::get('path'), 1));
+				C::set('url', dirname(C::get('currenturl'), 2) . C::get('path'));
 			}
-			
+
 			if (C::get('reinstall')) {
 				$status = -32;
 			}

--- a/lodel/scripts/context.php
+++ b/lodel/scripts/context.php
@@ -87,6 +87,7 @@ class C
 		self::$filter = null;
 		self::$_cfg = $cfg; // set the config vars
 		self::$_cfg['https'] = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? true : false);
+                self::$_cfg['base_url'] = isset($_SERVER['SERVER_NAME']) ? "${_SERVER['REQUEST_SCHEME']}://${_SERVER['SERVER_NAME']}" . (!in_array($_SERVER['SERVER_PORT'], ['80', '443']) ? $_SERVER['SERVER_PORT'] : '') : '';
 		$GLOBALS['tp'] = $GLOBALS['tableprefix'] = $cfg['tableprefix'];
 		defined('SITEROOT') || define('SITEROOT', '');
 		function_exists('cache_get') || include 'cachefunc.php';
@@ -325,7 +326,7 @@ class C
 			self::$_context['version'] = self::$_cfg['version'];
 			self::$_context['shareurl'] = self::$_cfg['shareurl'];
 			self::$_context['extensionscripts'] =self::$_cfg['extensionscripts'];
-			self::$_context['currenturl'] = isset($_SERVER['SERVER_NAME']) ? 'http'.(self::$_cfg['https'] ? 's' : '').'://'. $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT'] != 80 ? ':'. $_SERVER['SERVER_PORT'] : ''). $_SERVER['REQUEST_URI'] : '';
+			self::$_context['currenturl'] = self::$_cfg['base_url'] . $_SERVER['REQUEST_URI'];
 			self::$_context['siteroot'] = (defined('SITEROOT') ? SITEROOT : '');
 			self::$_context['sharedir'] = self::$_cfg['sharedir'];
 			self::$_context['tp'] = self::$_context['tableprefix'] = self::$_cfg['tableprefix'];

--- a/lodel/scripts/logic/class.users.php
+++ b/lodel/scripts/logic/class.users.php
@@ -393,7 +393,7 @@ class UsersLogic extends Logic
 			$context['sitetitle'] = $row['title'];
 			$context['islodeladmin'] = false;
 		} else { // lodeladmin
-			$context['siteurl'] = 'http://'. $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT']!=80 ? ':'. $_SERVER['SERVER_PORT'] : '').dirname($_SERVER['REQUEST_URI']);
+			$context['siteurl'] = dirname($context['currenturl'], 2);
 			$context['sitetitle'] = $context['siteurl'];
 			$context['islodeladmin'] = true;
 		}

--- a/lodel/scripts/view.php
+++ b/lodel/scripts/view.php
@@ -160,6 +160,7 @@ class View
 		global $db;
 
 		$idsession = C::get('idsession', 'lodeluser');
+
 		$offset = $back-1;
 		usemaindb();
 		// selectionne les urls dans la pile grâce à l'idsession et suivant la
@@ -172,16 +173,16 @@ class View
             		or trigger_error('SQL ERROR :<br />'.$GLOBALS['db']->ErrorMsg(), E_USER_ERROR);
 		$row = $result->fetchRow();
         	$result->Close();
-		$id = $row['id'];	
+		$id = $row['id'];
 		$newurl = $row['url'];
-		
+
 		if ($id) {
 			$db->execute(lq("
                  DELETE FROM #_TP_urlstack 
                     WHERE id>='{$id}' AND idsession='{$idsession}' AND site='".$this->_site."'")) 
                 		or trigger_error('SQL ERROR :<br />'.$GLOBALS['db']->ErrorMsg(), E_USER_ERROR);
 
-			$newurl = 'http'.(C::get('https', 'cfg') ? 's' : '').'://'. $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT'] != 80 ? ":". $_SERVER['SERVER_PORT'] : ''). $newurl;
+			$newurl = dirname(C::get('siteurl')) . $newurl;
 		} else {
 			$ext = defined('backoffice') || defined('backoffice-lodeladmin') ? 'php' : C::get('extensionscripts');
 			$newurl = "index.". $ext;

--- a/lodel/src/lodel/admin/login.php
+++ b/lodel/src/lodel/admin/login.php
@@ -18,10 +18,11 @@ try
     C::set('env', 'admin');
 
     $login = C::get('login');
-    
+
     if($login && C::get('passwd') && C::get('passwd2')) {
         include 'loginfunc.php';
         $retour = change_passwd(C::get('datab'), $login, C::get('old_passwd'), C::get('passwd'), C::get('passwd2'));
+
         switch($retour)
         {
             case true:
@@ -46,7 +47,7 @@ try
                         break;
                     } else {
                         check_internal_messaging();
-                        header ("Location: http".(C::get('https', 'cfg') ? 's' : '')."://". $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT'] != 80 ? ':'. $_SERVER['SERVER_PORT'] : ''). C::get('url_retour'));
+                        header("Location: " . $context['siteurl'] . C::get('url_retour'));
                     }
                 }
                 break;
@@ -88,7 +89,7 @@ try
                 }
             }
             check_internal_messaging();
-            header ("Location: http".(C::get('https', 'cfg') ? 's' : '')."://". $_SERVER['SERVER_NAME']. ($_SERVER['SERVER_PORT'] != 80 ? ':'. $_SERVER['SERVER_PORT'] : ''). C::get('url_retour'));
+            header("Location: " . $context['siteurl'] . C::get('url_retour'));
         } while (0);
     }
     


### PR DESCRIPTION
On unifie ici la récupération des URLs des sites afin de ne plus avoir une gestion
erronées des URLs en HTTPS où le port 443 se retrouve dans les urls
(ie : https://monsite:443/marevue/)