### PR TITLE
Correction du répertoire où sont sauvegardés les fichiers des plugins

### DIFF
--- a/lodel/scripts/logic/class.mainplugins.php
+++ b/lodel/scripts/logic/class.mainplugins.php
@@ -676,7 +676,7 @@ class MainPluginsLogic extends Logic
 				}
 			}
 
-			$err = validfield($context['data'][$name], $param['type'], $param['defaultValue'], $name, 'data', SITEROOT.'upload/plugins/'.$this->_plugin['name']);
+			$err = validfield($context['data'][$name], $param['type'], $param['defaultValue'], $name, 'data', 'upload/plugins/'.$this->_plugin['name']);
 
 			if(true !== $err)
 				$error[$name] = $err;


### PR DESCRIPTION
Le chemin vers le SITEROOT est déjà ajouté à postériori une fois le chemin vérifié,
il n'est pas nécessaire à l'appel de validfield