### PR TITLE
SQL error when no idtype is defined before running alphabetSpec loop

### DIFF
--- a/lodel/scripts/loops.php
+++ b/lodel/scripts/loops.php
@@ -851,8 +851,7 @@ function loop_alphabetSpec($context, $funcname)
 	}
 	
 	$status = C::get('editor', 'lodeluser') ? ' status > -64 ' : ' status > 0 ';
-	$sql2 = lq("SELECT COUNT({$context['field']}) as nbresults FROM #_TP_{$context['table']} WHERE {$whereCount} {$status} AND SUBSTRING({$context['field']},1,1) = ");
-
+	$sql2 = lq("SELECT COUNT({$context['field']}) as nbresults FROM #_TP_{$table} WHERE {$whereCount} {$status} AND SUBSTRING({$context['field']},1,1) = ");
 	$whereSelect .= !empty($whereSelect) ? ' AND '.$status : 'WHERE '.$status;	
 	$sql = "SELECT DISTINCT(SUBSTRING({$context['field']},1,1)) as l 
 			FROM #_TP_{$table} 


### PR DESCRIPTION
In this case, jointure with entities table should be included through ${table} placeholder but $context['table'] is set instead in the sql2 request. We get the following kind of request that provokes an error : SELECT COUNT(titreoeuvre) as nbresults FROM  textes WHERE status > 0  AND SUBSTRING(titreoeuvre,1,1) = 'A'