### PR TITLE
Strip tags in context inherited from $_GET

### DIFF
--- a/lodel/scripts/context.php
+++ b/lodel/scripts/context.php
@@ -228,7 +228,7 @@ class C
 						}
 
 						if ((strpos($value, '<?php') === false) && (strpos($value, '%3E?php') === false)) {
-							self::$_context[$k][] = $value;
+							self::$_context[$k][] = strip_tags($value);
 						}
 					}
 				}else {
@@ -240,7 +240,7 @@ class C
 
 
 					if ((strpos($v, '<?php') === false) && (strpos($v, '%3E?php') === false )) {
-						self::$_context[$k] = $v;
+						self::$_context[$k] = strip_tags($v);
 					}
 				}
 			}


### PR DESCRIPTION
Ce patch nettoie le contexte importé depuis les paramètres d'URL avec `strip_tags()` afin d'éviter les injections dans le Lodelscript. Cela suffit pour contrer la plupart des XSS signalées sur Open Bug Bounty. Voir mon mail à @rharoutiounian du 24/04/2025 pour connaître le détail des failles concernées.

Ce code est actuellement en prod sans bug constaté sur deux instance de Lodel.